### PR TITLE
refactor: implement canvas, remove font

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+M.canvas = nil
+M.x = nil
+M.y = nil
+
 local function text_center(text)
   local current_font = love.graphics.getFont()
   local text_height = current_font:getHeight()
@@ -21,32 +25,28 @@ local function splash_colored_text(r, g, b, text)
   -- TODO: Add fade in/fade out effect
 end
 
-function M.new(self, width, height)
+function M.new(width, height)
   local x_center = love.graphics.getWidth() / 2
   local y_center = love.graphics.getHeight() / 2
 
-  local x = x_center - (width / 2)
-  local y = y_center - (height / 2)
+  M.x = x_center - (width / 2)
+  M.y = y_center - (height / 2)
 
-  local canvas = love.graphics.newCanvas(width, height)
-  love.graphics.setCanvas(canvas)
+  M.canvas = love.graphics.newCanvas(width, height)
+  love.graphics.setCanvas(M.canvas)
   love.graphics.clear(love.math.colorFromBytes(30, 30, 46))
   love.graphics.setCanvas()
-
-  self.canvas = canvas
-  self.x = x
-  self.y = y
 end
 
-function M.start(self, time)
-  love.graphics.draw(self.canvas, self.x, self.y)
+function M.start(time)
+  love.graphics.draw(M.canvas, M.x, M.y)
 
   if time >= 3 then
-    love.graphics.draw(self.canvas, self.x, self.y)
+    love.graphics.draw(M.canvas, M.x, M.y)
     splash_colored_text(243, 139, 168, 'LÖVE')
   end
   if time >= 6 then
-    love.graphics.draw(self.canvas, self.x, self.y)
+    love.graphics.draw(M.canvas, M.x, M.y)
     splash_colored_text(205, 214, 244, 'cadin')
   end
   if time >= 9 then

--- a/init.lua
+++ b/init.lua
@@ -1,18 +1,5 @@
 local M = {}
 
-local function middle_screen_pos()
-  local x_center = love.graphics.getWidth() / 2
-  local y_center = love.graphics.getHeight() / 2
-
-  local width = 400
-  local height = 400
-
-  local x = x_center - (width / 2)
-  local y = y_center - (height / 2)
-
-  return x, y, width, height
-end
-
 local function text_center(text)
   local current_font = love.graphics.getFont()
   local text_height = current_font:getHeight()
@@ -28,43 +15,42 @@ local function splash_colored_text(r, g, b, text)
   local red, green, blue = love.math.colorFromBytes(r, g, b)
   local x, y, text_width = text_center(text)
 
-  love.graphics.setColor(red, green, blue)
-  love.graphics.printf(text, x, y, text_width, 'center')
+  local colored_text = { { red, green, blue }, text }
+
+  love.graphics.printf(colored_text, x, y, text_width, 'center')
   -- TODO: Add fade in/fade out effect
 end
 
-local function draw_splash_screen(r, g, b, text)
-  local x, y, w, h = middle_screen_pos()
+function M.new(self, width, height)
+  local x_center = love.graphics.getWidth() / 2
+  local y_center = love.graphics.getHeight() / 2
 
-  love.graphics.setColor(love.math.colorFromBytes(30, 30, 46))
-  love.graphics.rectangle('fill', x, y, w, h, 12)
+  local x = x_center - (width / 2)
+  local y = y_center - (height / 2)
 
-  if text then
-    splash_colored_text(r, g, b, text)
-  end
+  local canvas = love.graphics.newCanvas(width, height)
+  love.graphics.setCanvas(canvas)
+  love.graphics.clear(love.math.colorFromBytes(30, 30, 46))
+  love.graphics.setCanvas()
+
+  self.canvas = canvas
+  self.x = x
+  self.y = y
 end
 
-function M.load()
-  local r, g, b = love.math.colorFromBytes(24, 24, 37)
-  love.graphics.setBackgroundColor(r, g, b)
-
-  -- Assumes the following path on the root
-  local font_asset_path = 'assets/fonts/FiraMono-Medium.ttf'
-  local fira_mono = love.graphics.newFont(font_asset_path, 48)
-  love.graphics.setFont(fira_mono)
-end
-
-function M.draw(time)
-  draw_splash_screen()
+function M.start(self, time)
+  love.graphics.draw(self.canvas, self.x, self.y)
 
   if time >= 3 then
-    draw_splash_screen(243, 139, 168, 'LÖVE')
+    love.graphics.draw(self.canvas, self.x, self.y)
+    splash_colored_text(243, 139, 168, 'LÖVE')
   end
   if time >= 6 then
-    draw_splash_screen(205, 214, 244, 'cadin')
+    love.graphics.draw(self.canvas, self.x, self.y)
+    splash_colored_text(205, 214, 244, 'cadin')
   end
   if time >= 9 then
-    draw_splash_screen()
+    love.graphics.clear()
   end
 end
 


### PR DESCRIPTION
You can test it running the [available template](https://github.com/cadin-org/love-tmpl).

Four main changes:

- Remove the font: it now relies on the current one or default if none was set
- Use the appropriate `canvas` instead of `rectangle`
- Use the `coloredtext` table instead of string
- Use `clear` instead of `setColor` to handle colors

The downside is that I ended up using an OOP approach. Nonetheless, I have a feeling that there's still room to improve. But sooner or later we will find a better solution.